### PR TITLE
fix: build sharp when using pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,18 +13,27 @@
     "@nuxt/devtools": "^1.1.5",
     "@nuxt/ui": "^2.15.2",
     "@nuxthq/studio": "^1.0.13",
-    "nuxt": "^3.11.2",
+    "nuxt": "^3.15.2",
     "sass": "^1.75.0"
   },
   "dependencies": {
     "@iconify-json/mdi": "1.1.66",
     "@nuxt/content": "2.12.1",
-    "@nuxt/image": "1.5.0",
+    "@nuxt/image": "1.9.0",
     "@nuxt/ui-pro": "1.1.0",
     "@tailwindcss/forms": "0.5.7",
     "@tailwindcss/typography": "0.5.12",
     "@vueuse/nuxt": "10.9.0",
     "puppeteer": "22.6.5"
   },
-  "packageManager": "pnpm@10.1.0"
+  "packageManager": "pnpm@10.1.0",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp",
+      "esbuild",
+      "@parcel/watcher",
+      "vue-demi",
+      "puppeteer"
+    ]
+  }
 }

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -33,7 +33,7 @@
               v-for="(article, index) in filteredArticles" :key="index"
               class="bg-jm-secondary-grey-lighter">
             <NuxtLink class="grid items-end h-full" :to="article._path">
-              <NuxtImg class="w-full h-full" :src="article.image"/>
+              <NuxtImg class="w-full h-full" :src="article.image" format="webp"/>
               <section class="px-3 lg:px-7 pb-5">
                 <Paragraph class="mt-4 mb-2 text-sm font-light">{{ article.date }} von <b
                     class="text-jm-primary-green uppercase"> {{ article.author }} </b></Paragraph>

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -33,7 +33,7 @@
               v-for="(article, index) in filteredArticles" :key="index"
               class="bg-jm-secondary-grey-lighter">
             <NuxtLink class="grid items-end h-full" :to="article._path">
-              <NuxtImg class="w-full h-full" :src="article.image" format="webp"/>
+              <NuxtImg class="w-full h-full" :src="article.image"/>
               <section class="px-3 lg:px-7 pb-5">
                 <Paragraph class="mt-4 mb-2 text-sm font-light">{{ article.date }} von <b
                     class="text-jm-primary-green uppercase"> {{ article.author }} </b></Paragraph>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 2.12.1
         version: 2.12.1(db0@0.2.3)(ioredis@5.4.2)(magicast@0.3.5)(nuxt@3.15.4(@parcel/watcher@2.5.1)(@types/node@22.12.0)(db0@0.2.3)(ioredis@5.4.2)(magicast@0.3.5)(rollup@4.32.1)(sass@1.83.4)(terser@5.37.0)(typescript@5.7.3)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(sass@1.83.4)(terser@5.37.0)(yaml@2.7.0))(yaml@2.7.0))(rollup@4.32.1)(vue@3.5.13(typescript@5.7.3))
       '@nuxt/image':
-        specifier: 1.5.0
-        version: 1.5.0(db0@0.2.3)(ioredis@5.4.2)(magicast@0.3.5)(rollup@4.32.1)
+        specifier: 1.9.0
+        version: 1.9.0(db0@0.2.3)(ioredis@5.4.2)(magicast@0.3.5)(rollup@4.32.1)
       '@nuxt/ui-pro':
         specifier: 1.1.0
         version: 1.1.0(change-case@5.4.4)(magicast@0.3.5)(rollup@4.32.1)(typescript@5.7.3)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(sass@1.83.4)(terser@5.37.0)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
@@ -43,7 +43,7 @@ importers:
         specifier: ^1.0.13
         version: 1.1.2(magicast@0.3.5)(rollup@4.32.1)
       nuxt:
-        specifier: ^3.11.2
+        specifier: ^3.15.2
         version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@22.12.0)(db0@0.2.3)(ioredis@5.4.2)(magicast@0.3.5)(rollup@4.32.1)(sass@1.83.4)(terser@5.37.0)(typescript@5.7.3)(vite@6.0.11(@types/node@22.12.0)(jiti@2.4.2)(sass@1.83.4)(terser@5.37.0)(yaml@2.7.0))(yaml@2.7.0)
       sass:
         specifier: ^1.75.0
@@ -507,9 +507,9 @@ packages:
   '@nuxt/icon@1.10.3':
     resolution: {integrity: sha512-ESIiSIpETLLcn5p4U8S0F3AQ5Mox0MoHAVKczamY4STh3Dwrc8labLhtN6lunwpQEv6UGuiutdvfkJ88zu44Ew==}
 
-  '@nuxt/image@1.5.0':
-    resolution: {integrity: sha512-k1QvuGb3GCkpy35t8lpYjOjCDMajIIZ+vKw2XgRg89WlLDlpMNRPNBpSCn/9ixuly1LyjB4k5vggRJ2RxWVvsw==}
-    engines: {node: ^14.16.0 || >=16.11.0}
+  '@nuxt/image@1.9.0':
+    resolution: {integrity: sha512-kuuePx/jtlmsuG/G8mTMELntw4p8MLD4tu9f4A064xor/ks29oEoBmFRzvfFwxqZ7cqfG2M4LZfTZFjQz5St+Q==}
+    engines: {node: '>=18.20.5'}
 
   '@nuxt/kit@3.15.4':
     resolution: {integrity: sha512-dr7I7eZOoRLl4uxdxeL2dQsH0OrbEiVPIyBHnBpA4co24CBnoJoF+JINuP9l3PAM3IhUzc5JIVq3/YY3lEc3Hw==}
@@ -5086,16 +5086,15 @@ snapshots:
       - vite
       - vue
 
-  '@nuxt/image@1.5.0(db0@0.2.3)(ioredis@5.4.2)(magicast@0.3.5)(rollup@4.32.1)':
+  '@nuxt/image@1.9.0(db0@0.2.3)(ioredis@5.4.2)(magicast@0.3.5)(rollup@4.32.1)':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)(rollup@4.32.1)
       consola: 3.4.0
       defu: 6.1.4
       h3: 1.14.0
       image-meta: 0.2.1
-      node-fetch-native: 1.6.6
       ohash: 1.1.4
-      pathe: 1.1.2
+      pathe: 2.0.2
       std-env: 3.8.0
       ufo: 1.5.4
     optionalDependencies:


### PR DESCRIPTION
Error in blog was caused by switching to pnpm, sharp a dependency of NuxtImage was not build and binary was missing
Also updated Nuxt to latest and Nuxt image to latest

![grafik](https://github.com/user-attachments/assets/1391a388-fa85-4e99-81e1-e8645cf19182)
